### PR TITLE
test: Adopt JUnit5

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -10,24 +10,25 @@ on:
 jobs:
   build:
     name: Build and analyze
+    if: github.ref == 'refs/heads/master' && github.repository == 'flanglet/kanzi'  # ✅ Only for master branch of main repo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@main
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@main
         with:
           java-version: 17
           distribution: 'zulu' # Alternative distribution options are available.
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@main
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -35,10 +35,9 @@ configurations {
 }
 
 dependencies {
-//    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
-//    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
-//    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.4'
-    testImplementation 'junit:junit:+'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.11.4'
 
     // Java Doc in XML Format
     xmlDoclet('com.manticore-projects.tools:xml-doclet:+') { changing = true }
@@ -204,8 +203,7 @@ tasks.register('xmldoc', Javadoc) {
 }
 
 test {
-    //useJUnitPlatform()
-    useJUnit()   // Ensures the JUnit 4 test runner is used
+    useJUnitPlatform()
 
     // set heap size for the test JVM(s)
     minHeapSize = "128m"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -71,10 +71,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>[4.13.1,)</version>
-            <type>jar</type>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -153,6 +152,18 @@
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                    <useModulePath>false</useModulePath>
+                    <argLine>
+                        -Xmx2G -Xms800m -Xss4m
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/java/src/test/java/io/github/flanglet/kanzi/test/TestBWT.java
+++ b/java/src/test/java/io/github/flanglet/kanzi/test/TestBWT.java
@@ -18,25 +18,18 @@
 
 package io.github.flanglet.kanzi.test;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import io.github.flanglet.kanzi.ByteTransform;
 import io.github.flanglet.kanzi.SliceByteArray;
 import io.github.flanglet.kanzi.transform.BWT;
 import io.github.flanglet.kanzi.transform.BWTS;
-import org.junit.Assert;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestBWT {
   private final static Random RANDOM = new Random(Long.MAX_VALUE);
-
-  @Test
-  public void testBWT() {
-    Assert.assertTrue(testCorrectness(true, 200));
-    Assert.assertTrue(testCorrectness(false, 200));
-  }
 
 
   public static void printHexa(String s) {
@@ -72,19 +65,15 @@ public class TestBWT {
 
     System.out.println("TestBWT and TestBWTS");
 
-    if (testCorrectness(true, 20) == false)
-      System.exit(1);
-
-    if (testCorrectness(false, 20) == false)
-      System.exit(1);
-
     testSpeed(true, 200, 256 * 1024); // test MergeTPSI inverse
     testSpeed(true, 5, 10 * 1024 * 1024); // test BiPSIv2 inverse
     testSpeed(false, 200, 256 * 1024);
   }
 
 
-  public static boolean testCorrectness(boolean isBWT, int iters) {
+  @ParameterizedTest
+  @CsvSource({"true, 200", "false, 200"})
+  void testCorrectness(boolean isBWT, int iters) {
     System.out.println("\nBWT" + (!isBWT ? "S" : "") + " Correctness test");
 
     // Test behavior
@@ -171,9 +160,8 @@ public class TestBWT {
         System.out.println();
       }
 
-      if (str1.equals(str3) == true) {
-        System.out.println("Identical");
-      } else {
+      // @todo: Refactor this debugging related output
+      if (!str1.equals(str3)) {
         int idx = -1;
 
         for (int i = 0; i < buf1.length; i++) {
@@ -182,13 +170,11 @@ public class TestBWT {
             break;
           }
         }
-
         System.out.println("Different at index " + idx + " " + buf1[idx] + " <-> " + buf3[idx]);
-        return false;
       }
-    }
 
-    return true;
+      Assertions.assertEquals(str3, str1);
+    }
   }
 
 
@@ -206,14 +192,13 @@ public class TestBWT {
     for (int jj = 0; jj < 3; jj++) {
       long delta1 = 0;
       long delta2 = 0;
-      java.util.Random random = new java.util.Random();
       long before, after;
 
       for (int ii = 0; ii < iter; ii++) {
         ByteTransform bwt = (isBWT) ? new BWT() : new BWTS();
 
         for (int i = 0; i < size; i++)
-          buf1[i] = (byte) (random.nextInt(255) + 1);
+          buf1[i] = (byte) (RANDOM.nextInt(255) + 1);
 
         before = System.nanoTime();
         sa1.index = 0;
@@ -221,6 +206,7 @@ public class TestBWT {
         bwt.forward(sa1, sa2);
         after = System.nanoTime();
         delta1 += (after - before);
+
         before = System.nanoTime();
         sa2.index = 0;
         sa3.index = 0;

--- a/java/src/test/java/io/github/flanglet/kanzi/test/TestEntropyCodec.java
+++ b/java/src/test/java/io/github/flanglet/kanzi/test/TestEntropyCodec.java
@@ -18,7 +18,6 @@
 
 package io.github.flanglet.kanzi.test;
 
-import io.github.flanglet.kanzi.BitStreamException;
 import io.github.flanglet.kanzi.entropy.BinaryEntropyDecoder;
 import io.github.flanglet.kanzi.entropy.BinaryEntropyEncoder;
 import java.io.ByteArrayInputStream;
@@ -46,8 +45,10 @@ import io.github.flanglet.kanzi.entropy.FPAQEncoder;
 import io.github.flanglet.kanzi.entropy.RangeDecoder;
 import io.github.flanglet.kanzi.entropy.RangeEncoder;
 import io.github.flanglet.kanzi.entropy.TPAQPredictor;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 
 public class TestEntropyCodec {
@@ -67,86 +68,41 @@ public class TestEntropyCodec {
       if (type.equals("ALL")) {
         System.out.println("\n\nTest Huffman Codec");
 
-        if (testCorrectness("HUFFMAN") == false)
-          System.exit(1);
 
         testSpeed("HUFFMAN", 200);
         System.out.println("\n\nTest ANS0 Codec");
 
-        if (testCorrectness("ANS0") == false)
-          System.exit(1);
 
         testSpeed("ANS0", 200);
         System.out.println("\n\nTest ANS1 Codec");
 
-        if (testCorrectness("ANS1") == false)
-          System.exit(1);
 
         testSpeed("ANS1", 150);
         System.out.println("\n\nTest Range Codec");
 
-        if (testCorrectness("RANGE") == false)
-          System.exit(1);
 
         testSpeed("RANGE", 150);
         System.out.println("\n\nTest FPAQ Codec");
 
-        if (testCorrectness("FPAQ") == false)
-          System.exit(1);
 
         testSpeed("FPAQ", 120);
         System.out.println("\n\nTest CM Codec");
 
-        if (testCorrectness("CM") == false)
-          System.exit(1);
 
         testSpeed("CM", 100);
         System.out.println("\n\nTestTPAQCodec");
 
-        if (testCorrectness("TPAQ") == false)
-          System.exit(1);
 
         testSpeed("TPAQ", 75);
         System.out.println("\n\nTestExpGolombCodec");
 
-        if (testCorrectness("EXPGOLOMB") == false)
-          System.exit(1);
 
         testSpeed("EXPGOLOMB", 150);
       } else {
         System.out.println("Test " + type + " Codec");
-        testCorrectness(type);
         testSpeed(type, 100);
       }
     }
-  }
-
-  @Test
-  public void testEntropy() {
-    System.out.println("\n\nTest Huffman Codec");
-    Assert.assertTrue(testCorrectness("HUFFMAN"));
-    // testSpeed("HUFFMAN");
-    System.out.println("\n\nTest ANS0 Codec");
-    Assert.assertTrue(testCorrectness("ANS0"));
-    // testSpeed("ANS0");
-    System.out.println("\n\nTest ANS1 Codec");
-    Assert.assertTrue(testCorrectness("ANS1"));
-    // testSpeed("ANS1");
-    System.out.println("\n\nTest Range Codec");
-    Assert.assertTrue(testCorrectness("RANGE"));
-    // testSpeed("RANGE");
-    System.out.println("\n\nTest FPAQ Codec");
-    Assert.assertTrue(testCorrectness("FPAQ"));
-    // testSpeed("FPAQ");
-    System.out.println("\n\nTest CM Codec");
-    Assert.assertTrue(testCorrectness("CM"));
-    // testSpeed("CM");
-    System.out.println("\n\nTest TPAQ Codec");
-    Assert.assertTrue(testCorrectness("TPAQ"));
-    // testSpeed("TPAQ");
-    System.out.println("\n\nTest ExpGolomb Codec");
-    Assert.assertTrue(testCorrectness("EXPGOLOMB"));
-    // testSpeed("EXPGOLOMB");
   }
 
 
@@ -233,96 +189,93 @@ public class TestEntropyCodec {
   }
 
 
-  public static boolean testCorrectness(String name) {
+  @ParameterizedTest
+  @CsvSource({"HUFFMAN", "ANS0", "ANS1", "RANGE", "FPAQ", "CM", "TPAQ", "TPAQ", "EXPGOLOMB"})
+  void testCorrectness(String name) {
     // Test behavior
     System.out.println("Correctness test for " + name);
 
     for (int ii = 1; ii < 20; ii++) {
       System.out.println("\n\nTest " + ii);
 
-      try {
-        byte[] values;
+      int finalii = ii;
+      Assertions.assertDoesNotThrow(new Executable() {
 
-        if (ii == 3)
-          values = new byte[] {0, 0, 32, 15, -4, 16, 0, 16, 0, 7, -1, -4, -32, 0, 31, -1};
-        else if (ii == 2)
-          values =
-              new byte[] {61, 77, 84, 71, 90, 54, 57, 38, 114, 111, 108, 101, 61, 112, 114, 101};
-        else if (ii == 1) {
-          values = new byte[40];
+        @Override
+        public void execute() throws Throwable {
+          byte[] values;
 
-          for (int i = 0; i < values.length; i++)
-            values[i] = (byte) 2; // all identical
-        } else if (ii == 4) {
-          values = new byte[40];
+          if (finalii == 3)
+            values = new byte[] {0, 0, 32, 15, -4, 16, 0, 16, 0, 7, -1, -4, -32, 0, 31, -1};
+          else if (finalii == 2)
+            values =
+                new byte[] {61, 77, 84, 71, 90, 54, 57, 38, 114, 111, 108, 101, 61, 112, 114, 101};
+          else if (finalii == 1) {
+            values = new byte[40];
 
-          for (int i = 0; i < values.length; i++)
-            values[i] = (byte) (2 + (i & 1)); // 2 symbols
-        } else if (ii == 5) {
-          values = new byte[] {42};
-        } else if (ii == 6) {
-          values = new byte[] {42, 42};
-        } else {
-          values = new byte[256];
+            for (int i = 0; i < values.length; i++)
+              values[i] = (byte) 2; // all identical
+          } else if (finalii == 4) {
+            values = new byte[40];
 
-          for (int i = 0; i < values.length; i++)
-            values[i] = (byte) (64 + 4 * ii + TestEntropyCodec.RANDOM.nextInt(8 * ii + 1));
-        }
+            for (int i = 0; i < values.length; i++)
+              values[i] = (byte) (2 + (i & 1)); // 2 symbols
+          } else if (finalii == 5) {
+            values = new byte[] {42};
+          } else if (finalii == 6) {
+            values = new byte[] {42, 42};
+          } else {
+            values = new byte[256];
 
-        System.out.println("Original:");
-
-        for (int i = 0; i < values.length; i++)
-          System.out.print((values[i] & 0xFF) + " ");
-
-        System.out.println();
-        System.out.println("\nEncoded:");
-        ByteArrayOutputStream os = new ByteArrayOutputStream(16384);
-        OutputBitStream obs = new DefaultOutputBitStream(os, 16384);
-        DebugOutputBitStream dbgbs = new DebugOutputBitStream(obs, System.out);
-        dbgbs.showByte(true);
-        EntropyEncoder ec = getEncoder(name, dbgbs);
-
-        if (ec == null)
-          return false;
-
-        ec.encode(values, 0, values.length);
-        ec.dispose();
-        dbgbs.close();
-        byte[] buf = os.toByteArray();
-        InputBitStream ibs = new DefaultInputBitStream(new ByteArrayInputStream(buf), 1024);
-        EntropyDecoder ed = getDecoder(name, ibs);
-
-        if (ed == null)
-          return false;
-
-        System.out.println();
-        System.out.println("\nDecoded:");
-        boolean ok = true;
-        byte[] values2 = new byte[values.length];
-        ed.decode(values2, 0, values2.length);
-        ed.dispose();
-        ibs.close();
-
-        try {
-          for (int j = 0; j < values2.length; j++) {
-            if (values[j] != values2[j])
-              ok = false;
-
-            System.out.print((values2[j] & 0xFF) + " ");
+            for (int i = 0; i < values.length; i++)
+              values[i] =
+                  (byte) (64 + 4 * finalii + TestEntropyCodec.RANDOM.nextInt(8 * finalii + 1));
           }
-        } catch (BitStreamException e) {
-          e.printStackTrace();
-          return false;
+
+          System.out.println("Original:");
+
+          for (int i = 0; i < values.length; i++)
+            System.out.print((values[i] & 0xFF) + " ");
+
+          System.out.println();
+          System.out.println("\nEncoded:");
+          ByteArrayOutputStream os = new ByteArrayOutputStream(16384);
+          OutputBitStream obs = new DefaultOutputBitStream(os, 16384);
+          DebugOutputBitStream dbgbs = new DebugOutputBitStream(obs, System.out);
+          dbgbs.showByte(true);
+          EntropyEncoder ec = getEncoder(name, dbgbs);
+
+          Assertions.assertNotNull(ec);
+
+          ec.encode(values, 0, values.length);
+          ec.dispose();
+          dbgbs.close();
+          byte[] buf = os.toByteArray();
+          InputBitStream ibs = new DefaultInputBitStream(new ByteArrayInputStream(buf), 1024);
+          EntropyDecoder ed = getDecoder(name, ibs);
+
+          Assertions.assertNotNull(ed);
+
+          System.out.println();
+          System.out.println("\nDecoded:");
+          byte[] values2 = new byte[values.length];
+          ed.decode(values2, 0, values2.length);
+          ed.dispose();
+          ibs.close();
+
+          Assertions.assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() throws Throwable {
+              for (int j = 0; j < values2.length; j++) {
+                Assertions.assertEquals(values[j], values2[j]);
+                System.out.print((values2[j] & 0xFF) + " ");
+              }
+            }
+          });
+          // System.out.println("\n" + ((ok == true) ? "Identical" : "Different"));
         }
-
-        System.out.println("\n" + ((ok == true) ? "Identical" : "Different"));
-      } catch (Exception e) {
-        e.printStackTrace();
-        return false;
-      }
+      });
     }
-
-    return true;
   }
 
 

--- a/java/src/test/java/io/github/flanglet/kanzi/test/TestTransforms.java
+++ b/java/src/test/java/io/github/flanglet/kanzi/test/TestTransforms.java
@@ -32,8 +32,10 @@ import io.github.flanglet.kanzi.transform.SBRT;
 import io.github.flanglet.kanzi.transform.SRT;
 import io.github.flanglet.kanzi.transform.TransformFactory;
 import io.github.flanglet.kanzi.transform.ZRLT;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 
 public class TestTransforms {
@@ -53,119 +55,55 @@ public class TestTransforms {
       if (type.equals("ALL")) {
         System.out.println("\n\nTestLZ");
 
-        if (testCorrectness("LZ") == false)
-          System.exit(1);
 
         testSpeed("LZ");
         System.out.println("\n\nTestLZX");
 
-        if (testCorrectness("LZX") == false)
-          System.exit(1);
 
         testSpeed("LZX");
         System.out.println("\n\nTestLZP");
 
-        if (testCorrectness("LZP") == false)
-          System.exit(1);
 
         // testSpeed("LZP"); skip (returns false if not good enough compression)
         System.out.println("\n\nTestROLZ");
 
-        if (testCorrectness("ROLZ") == false)
-          System.exit(1);
 
         testSpeed("ROLZ");
         System.out.println("\n\nTestROLZX");
 
-        if (testCorrectness("ROLZX") == false)
-          System.exit(1);
 
         testSpeed("ROLZX");
         System.out.println("\n\nTestZRLT");
 
-        if (testCorrectness("ZRLT") == false)
-          System.exit(1);
 
         testSpeed("ZRLT");
         System.out.println("\n\nTestRLT");
 
-        if (testCorrectness("RLT") == false)
-          System.exit(1);
 
         testSpeed("RLT");
         System.out.println("\n\nTestSRT");
 
-        if (testCorrectness("SRT") == false)
-          System.exit(1);
 
         testSpeed("SRT");
         System.out.println("\n\nTestRANK");
 
-        if (testCorrectness("RANK") == false)
-          System.exit(1);
 
         testSpeed("RANK");
         System.out.println("\n\nTestMTFT");
 
-        if (testCorrectness("MTFT") == false)
-          System.exit(1);
 
         testSpeed("MTFT");
         System.out.println("\n\nTestFSD");
-
-        if (testCorrectness("FSD") == false)
-          System.exit(1);
 
         // testSpeed("FSD"); no good data
       } else {
         System.out.println("Test" + type);
 
-        if (testCorrectness(type) == false)
-          System.exit(1);
 
         testSpeed(type);
       }
     }
   }
-
-
-  @Test
-  public void testTransforms() {
-    System.out.println("\n\nTestRANK");
-    Assert.assertTrue(testCorrectness("RANK"));
-    // testSpeed("RANK");
-    System.out.println("\n\nTestMTFT");
-    Assert.assertTrue(testCorrectness("MTFT"));
-    // testSpeed("MTFT");
-    System.out.println("\n\nTestSRT");
-    Assert.assertTrue(testCorrectness("SRT"));
-    // testSpeed("SRT");
-    System.out.println("\n\nTestLZ");
-    Assert.assertTrue(testCorrectness("LZ"));
-    // testSpeed("LZ");
-    System.out.println("\n\nTestLZX");
-    Assert.assertTrue(testCorrectness("LZX"));
-    // testSpeed("LZX");
-    System.out.println("\n\nTestLZP");
-    Assert.assertTrue(testCorrectness("LZP"));
-    // testSpeed("LZP");
-    System.out.println("\n\nTestROLZ");
-    Assert.assertTrue(testCorrectness("ROLZ"));
-    // testSpeed("ROLZ");
-    System.out.println("\n\nTestROLZX");
-    Assert.assertTrue(testCorrectness("ROLZX"));
-    // testSpeed("ROLZX");
-    System.out.println("\n\nTestZRLT");
-    Assert.assertTrue(testCorrectness("ZRLT"));
-    // testSpeed("ZRLT");
-    System.out.println("\n\nTestFSD");
-    Assert.assertTrue(testCorrectness("MM"));
-    // testSpeed("MM");
-    System.out.println("\n\nTestRLT");
-    Assert.assertTrue(testCorrectness("RLT"));
-    // testSpeed("RLT");
-  }
-
 
   private static ByteTransform getTransform(String name) {
     switch (name) {
@@ -212,8 +150,9 @@ public class TestTransforms {
     }
   }
 
-
-  private static boolean testCorrectness(String name) {
+  @ParameterizedTest
+  @CsvSource({"RANK", "MTFT", "SRT", "LZ", "LZX", "LZP", "ROLZ", "ROLZX", "ZRLT", "MM", "RLT"})
+  void testCorrectness(String name) {
     byte[] input;
     byte[] output;
     byte[] reverse;
@@ -224,7 +163,7 @@ public class TestTransforms {
 
     for (int ii = 0; ii <= 50; ii++) {
       System.out.println("\nTest " + ii);
-      int[] arr = new int[0];
+      int[] arr;
 
       if (ii == 0) {
         arr = new int[] {0, 1, 2, 2, 2, 2, 7, 9, 9, 16, 16, 16, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -343,10 +282,7 @@ public class TestTransforms {
       sa2.index = 0;
       sa3.index = 0;
 
-      if (f.inverse(sa2, sa3) == false) {
-        System.out.println("Decoding error");
-        return false;
-      }
+      Assertions.assertTrue(f.inverse(sa2, sa3));
 
       System.out.println();
       System.out.println("Decoded: ");
@@ -379,13 +315,13 @@ public class TestTransforms {
           System.out.println(i + ": " + sa1.array[i] + " " + sa3.array[i]);
 
         System.out.println(idx + ": " + sa1.array[idx] + "* " + sa3.array[idx] + "*");
-        return false;
       }
+
+      Assertions.assertEquals(-1, idx); // , "Different (index " + idx + ": " + input[idx] + " - " +
+                                        // reverse[idx] + ")");
 
       System.out.println();
     }
-
-    return true;
   }
 
 


### PR DESCRIPTION
- use Parametrized Tests where possible
- use Assertions where possible
- check for Throws/DoesNotThrow where possible

The main advantage is proper IDE support with executable tests (in Netbeans and IntelliJ) as well as parallel execution.

I still would like to suggest to:

1) move the `testSpeed` benchmarks into its own Benchmark package (possibly using PMD for micro benchmarking)
2) replacing any `System.out` by proper loggers (it is very noisy right now)
3) remove the `ant` build file (because `ant` is really dead)

Do let me know how you feel about that.